### PR TITLE
Resolved bento warnings

### DIFF
--- a/adjust
+++ b/adjust
@@ -307,7 +307,7 @@ class GitOps(Adjust):
         os.chdir(self.clone_dir)
         try:
             self._run_command(['git', 'diff-index', '--quiet', 'HEAD', '--'])
-        except Exception as e:
+        except Exception as e: # nosec (desired functionality, drops through to the add, commit, push logic)
             pass
         else:
             os.chdir(self.cwd)
@@ -396,7 +396,7 @@ class GitOps(Adjust):
     # expansion, etc.  The burden of safety is entirely on the user.
     def _run_shell_command(self, cmd, tout=None, cmd_type='Driver shell command'):
         res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            shell=True, timeout=tout, executable='/bin/bash')
+            shell=True, timeout=tout, executable='/bin/bash') # nosec (see shell=true disclaimer in above comment)
         msg = "cmd '{}', exit code {}, stdout {}, stderr {}".format(cmd,
             res.returncode, res.stdout, res.stderr)
         assert res.returncode == 0, '{} failed:  {}'.format(cmd_type, msg)

--- a/formula.py
+++ b/formula.py
@@ -43,5 +43,5 @@ def evaluate(expr, var):
     Note that vars will shadow any of the standard const/funcs, e.g., if a var 'pi'
     is included in the vars arg, it will shadow the standard math.pi value.
     '''
-    ret = eval(expr, get_gbl(), var)
+    ret = eval(expr, get_gbl(), var) # nosec (globals/locals constrained to safe subset)
     return ret


### PR DESCRIPTION
Bento Output:

```
bandit try-except-pass https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
     > adjust:310                                                                     
     ╷                                                                                
  310│   except Exception as e:                                                       
     ╵                                                                                
     = Try, Except, Pass detected.

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > adjust:399
     ╷
  399│   res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
  400│       shell=True, timeout=tout, executable='/bin/bash')
     ╵
     = subprocess call with shell=True identified, security issue.

bandit eval-used https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b307-eval
     > formula.py:46
     ╷
   46│   ret = eval(expr, get_gbl(), var)
     ╵
     = Use of possibly insecure function - consider using safer
       ast.literal_eval.
```